### PR TITLE
Add option to use SimilarityModel3D

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>mpicbg</groupId>
 			<artifactId>mpicbg</artifactId>
-			<version>1.0.1</version>
+			<version>1.1.1</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/plugin/Descriptor_based_registration.java
+++ b/src/main/java/plugin/Descriptor_based_registration.java
@@ -22,6 +22,7 @@ import mpicbg.models.InvertibleBoundable;
 import mpicbg.models.RigidModel2D;
 import mpicbg.models.RigidModel3D;
 import mpicbg.models.SimilarityModel2D;
+import mpicbg.models.SimilarityModel3D;
 import mpicbg.models.TranslationModel2D;
 import mpicbg.models.TranslationModel3D;
 import mpicbg.spim.segmentation.InteractiveDoG;
@@ -161,7 +162,7 @@ public class Descriptor_based_registration implements PlugIn
 	}
 	
 	public String[] transformationModels2d = new String[] { "Translation (2d)", "Rigid (2d)", "Similarity (2d)", "Affine (2d)", "Homography (2d)" };
-	public String[] transformationModels3d = new String[] { "Translation (3d)", "Rigid (3d)", "Affine (3d)" };
+	public String[] transformationModels3d = new String[] { "Translation (3d)", "Rigid (3d)", "Similarity (3d)", "Affine (3d)" };
 	public static int defaultTransformationModel = 1;
 	public static int defaultRegularizationTransformationModel = 1;
 	public static double defaultLambda = 0.1;
@@ -368,6 +369,9 @@ public class Descriptor_based_registration implements PlugIn
 					params.model = new RigidModel3D();
 					break;
 				case 2:
+					params.model = new SimilarityModel3D();
+					break;
+				case 3:
 					params.model = new AffineModel3D();
 					break;
 				default:
@@ -429,6 +433,9 @@ public class Descriptor_based_registration implements PlugIn
 						params.model = new InterpolatedAffineModel3D( params.model, new RigidModel3D(), (float)params.lambda );
 						break;
 					case 2:
+						params.model = new InterpolatedAffineModel3D( params.model, new SimilarityModel3D(), (float)params.lambda );
+						break;
+					case 3:
 						params.model = new InterpolatedAffineModel3D( params.model, new AffineModel3D(), (float)params.lambda );
 						break;
 					default:
@@ -601,7 +608,7 @@ public class Descriptor_based_registration implements PlugIn
 				// set the model as initial guess
 				params.initialModel = m1;
 			}
-			else if ( AffineModel3D.class.isInstance( params.model ) )
+			else if ( AffineModel3D.class.isInstance( params.model ) || SimilarityModel3D.class.isInstance( params.model ) )
 			{
 				final GenericDialog gd2 = new GenericDialog( "Model parameters for affine model 3d" );
 				
@@ -770,6 +777,7 @@ public class Descriptor_based_registration implements PlugIn
 			else
 			{
 				IJ.log( "Unfortunately this is not supported this model yet ... " );
+				IJ.log(params.model.getClass().toString());
 				return null;
 			}
 		}

--- a/src/main/java/plugin/Descriptor_based_series_registration.java
+++ b/src/main/java/plugin/Descriptor_based_series_registration.java
@@ -22,6 +22,7 @@ import mpicbg.models.InvertibleBoundable;
 import mpicbg.models.RigidModel2D;
 import mpicbg.models.RigidModel3D;
 import mpicbg.models.SimilarityModel2D;
+import mpicbg.models.SimilarityModel3D;
 import mpicbg.models.TranslationModel2D;
 import mpicbg.models.TranslationModel3D;
 import mpicbg.spim.segmentation.InteractiveDoG;
@@ -181,7 +182,7 @@ public class Descriptor_based_series_registration implements PlugIn
 	}
 
 	public String[] transformationModels2d = new String[] { "Translation (2d)", "Rigid (2d)", "Similarity (2d)", "Affine (2d)", "Homography (2d)" };
-	public String[] transformationModels3d = new String[] { "Translation (3d)", "Rigid (3d)", "Affine (3d)" };
+	public String[] transformationModels3d = new String[] { "Translation (3d)", "Rigid (3d)", "Similarity (3d)", "Affine (3d)" };
 	public static String[] localizationChoice = { "None", "3-dimensional quadratic fit", "Gaussian mask localization fit" };
 	public static int defaultTransformationModel = 1;
 	public static int defaultLocalization = 1;
@@ -383,6 +384,9 @@ public class Descriptor_based_series_registration implements PlugIn
 					params.model = new RigidModel3D();
 					break;
 				case 2:
+					params.model = new SimilarityModel3D();
+					break;
+				case 3:
 					params.model = new AffineModel3D();
 					break;
 				default:
@@ -445,6 +449,9 @@ public class Descriptor_based_series_registration implements PlugIn
 						params.model = new InterpolatedAffineModel3D( params.model, new RigidModel3D(), (float)params.lambda );
 						break;
 					case 2:
+						params.model = new InterpolatedAffineModel3D( params.model, new SimilarityModel3D(), (float)params.lambda );
+						break;
+					case 3:
 						params.model = new InterpolatedAffineModel3D( params.model, new AffineModel3D(), (float)params.lambda );
 						break;
 					default:


### PR DESCRIPTION
This allows to choose a Similarity (3d) model that was introduced with mpicbg-1.1.1

NB: While testing, I noticed that the option to provide an own approximate alignment when regularizing the model will always fail with:

    Unfortunately this is not supported this model yet ... 

even in the current version of the plugin, because `params.model` will be of class `class mpicbg.models.InterpolatedAffineModel3D`.
